### PR TITLE
Fix skinned MV stalls from reading mapped upload memory

### DIFF
--- a/src/D3D11Hook.cpp
+++ b/src/D3D11Hook.cpp
@@ -2163,8 +2163,8 @@ static void STDMETHODCALLTYPE HookedDraw(
         if (dip == static_cast<DustInjectionPoint>(InjectionPoint::POST_LIGHTING))
         {
             ExtractCameraData(pThis);
-            // Repack this frame's skinned poses (GBuffer captures are resolved now) so next frame's
-            // patched skin VS can read them as "previous" from b12 and emit true animation velocity.
+            // Repack this frame's skinned poses so next frame's patched skin VS can read them as
+            // "previous" from b12 and emit true animation velocity.
             if (sMvFeederActive)
                 MotionVectors::InjFillSkinPrev(pThis);
         }
@@ -2240,16 +2240,10 @@ static void STDMETHODCALLTYPE HookedDrawIndexed(
     if (IconDrawLogEnabled())
         LogIconDraw(pThis, "DI", IndexCount, 1);
 
-    // Motion-vector pass: snapshot this GBuffer draw's transform state. Fast-path
-    // no-op unless capture is enabled AND we're inside the GBuffer pass.
-    if (GeometryCapture::HasActiveCapture())
-    {
-        GeometryCapture::OnDrawIndexed(pThis, IndexCount, StartIndexLocation, BaseVertexLocation);
-        // If that draw was skinned, bind its matched previous-frame bone palette at b12 so the patched
-        // skin VS can emit true animation velocity (must be after OGRE's per-draw constant setup).
-        if (sMvFeederActive)
-            MotionVectors::InjBindSkinPrev(pThis);
-    }
+    // The injected path only needs the current VS, skin CB and index buffer. Avoid the legacy full
+    // CapturedDraw snapshot, whose replay-only IA/SRV/sampler queries dominated character-heavy scenes.
+    if (sMvFeederActive && GeometryCapture::HasActiveCapture())
+        MotionVectors::InjBindSkinPrev(pThis, IndexCount, BaseVertexLocation);
 
     // Direct-light AO for point/spot lights: for a light_fs draw, swap the AO snapshot
     // into s8/s9 for the draw and restore afterward (scope dtor). gLvAoReady gates the
@@ -2279,18 +2273,9 @@ static void STDMETHODCALLTYPE HookedDrawIndexedInstanced(
     if (IconDrawLogEnabled())
         LogIconDraw(pThis, "DII", IndexCountPerInstance, InstanceCount);
 
-    // Motion-vector pass: snapshot this instanced GBuffer draw (per-instance
-    // transform VB is captured too — see GeometryCapture::CaptureDrawState).
-    if (GeometryCapture::HasActiveCapture())
-    {
-        GeometryCapture::OnDrawIndexedInstanced(pThis, IndexCountPerInstance, InstanceCount,
-                                                StartIndexLocation, BaseVertexLocation,
-                                                StartInstanceLocation);
-        // Instanced draws skip the pose matcher, but an instanced SKINNED draw's patched VS still
-        // reads b12 — bind the zero CB so it gets the camera-reproj fallback, not a stale pose.
-        if (sMvFeederActive)
-            MotionVectors::InjBindZeroB12(pThis);
-    }
+    // Instanced skin draws skip pose matching but must not inherit another character's sticky b12.
+    if (sMvFeederActive && GeometryCapture::HasActiveCapture())
+        MotionVectors::InjBindZeroB12(pThis);
 
     // Direct-light AO for point/spot lights (instanced light-volume path — see HookedDrawIndexed).
     bool isLV = gLvAoReady && IsLightVolumeDraw(pThis);
@@ -2323,17 +2308,16 @@ static void STDMETHODCALLTYPE HookedDrawInstanced(
     oDrawInstanced(pThis, VertexCountPerInstance, InstanceCount, StartVertexLocation, StartInstanceLocation);
 }
 
-// Map/Unmap: shadow the skinned bone-palette CB as OGRE writes it (WRITE_DISCARD before each skin
-// draw), so InjBindSkinPrev can read the CURRENT frame's root bone at draw time — the key to spatial
-// (nearest-root) prev-pose matching without a GPU read-back stall. MotionVectors gates the fast path
-// on having learned a bone CB, so the overhead is one hash lookup per Map/Unmap until then.
+// Map/Unmap: proxy known skinned bone-palette WRITE_DISCARD buffers through cached CPU RAM. At Unmap
+// the cached bytes are written to the real mapped GPU pointer (never read back from write-combined
+// upload memory), while remaining available for current-root matching.
 static HRESULT STDMETHODCALLTYPE HookedMap(
     ID3D11DeviceContext* pThis, ID3D11Resource* pResource, UINT Subresource,
     D3D11_MAP MapType, UINT MapFlags, D3D11_MAPPED_SUBRESOURCE* pMappedResource)
 {
     HRESULT hr = oMap(pThis, pResource, Subresource, MapType, MapFlags, pMappedResource);
     if (!gShutdownSignaled && SUCCEEDED(hr) && Subresource == 0 && pMappedResource && sMvFeederActive)
-        MotionVectors::InjNoteMap(pResource, pMappedResource->pData);
+        MotionVectors::InjNoteMap(pResource, MapType, pMappedResource);
     return hr;
 }
 
@@ -3347,8 +3331,8 @@ bool Install()
                            (void**)&oDrawInstanced) != KenshiLib::SUCCESS)
     { Log("WARNING: Failed to hook DrawInstanced (non-indexed instanced MV will be wrong)"); }
 
-    // Map/Unmap: needed to shadow the skinned bone-palette CB for spatial prev-pose matching.
-    // Non-fatal if it fails — skinned animation MVs just fall back to zero (camera reproj only).
+    // Map/Unmap: needed to proxy and shadow the skinned bone-palette CB for spatial pose matching.
+    // Non-fatal if it fails — skinned animation MVs fall back to camera reprojection.
     if (KenshiLib::AddHook(addrMap, (void*)HookedMap,
                            (void**)&oMap) != KenshiLib::SUCCESS)
     { Log("WARNING: Failed to hook Map (skinned animation motion vectors disabled)"); }

--- a/src/MotionVectors.cpp
+++ b/src/MotionVectors.cpp
@@ -935,10 +935,23 @@ static void BindSkinZeroB12(ID3D11DeviceContext* ctx)
     if (sSkinZeroB12) ctx->VSSetConstantBuffers(12, 1, &sSkinZeroB12);
 }
 
+// The live injected-MV path only needs shader classification for every GBuffer draw. Query the
+// currently-bound VS, resolve its persistent registry metadata, and immediately release the COM ref.
+// This replaces the legacy full CapturedDraw snapshot used by the abandoned geometry-replay path.
+static const VSConstantBufferInfo* CurrentVSInfo(ID3D11DeviceContext* ctx)
+{
+    if (!ctx) return nullptr;
+    ID3D11VertexShader* vs = nullptr;
+    ctx->VSGetShader(&vs, nullptr, nullptr);
+    const VSConstantBufferInfo* info = vs ? ShaderMetadata::GetVSInfo(vs) : nullptr;
+    if (vs) vs->Release();
+    return info;
+}
+
 struct SkinPose {
     std::vector<uint8_t> b12;      // b12 layout: bones @0 (2880B) + viewProjectionMatrix @2880 (64B)
     float root[3] = {0,0,0};       // bone0 translation (rebased world) — the spatial match key
-    ID3D11Buffer* ib = nullptr;    // mesh identity (raw ptr; OGRE reuses the same IB per mesh)
+    ID3D11Buffer* ib = nullptr;    // mesh identity (raw ptr; no retained reference)
     uint32_t idxCount = 0;
     int32_t  baseVtx = 0;
 };
@@ -953,8 +966,16 @@ static uint32_t sSkinDiagFrame = 0;
 // (needed to spatially match against last frame) without a GPU read-back stall.
 static bool sBoneShadowActive = false;                                        // gate the Map/Unmap fast path
 static std::unordered_map<const void*, uint32_t>            sKnownBoneCB;      // buffer -> byte size
-static std::unordered_map<const void*, void*>              sMapPending;        // buffer -> pData (Map..Unmap)
-static std::unordered_map<const void*, std::vector<uint8_t>> sBoneShadow;      // buffer -> last-unmapped bytes
+static std::unordered_map<const void*, ID3D11Buffer*>       sHeldBoneCB;       // prevents pointer recycling
+static std::unordered_map<const void*, void*>               sMapPending;        // buffer -> real GPU pData
+static std::unordered_map<const void*, std::vector<uint8_t>> sBoneShadow;       // cached-RAM proxy + shadow
+
+static void ClearBoneShadows()
+{
+    for (auto& kv : sHeldBoneCB) if (kv.second) kv.second->Release();
+    sKnownBoneCB.clear(); sHeldBoneCB.clear(); sMapPending.clear(); sBoneShadow.clear();
+    sBoneShadowActive = false;
+}
 
 ID3D11RenderTargetView* InjEnsureVelRTV(ID3D11RenderTargetView* refRTV)
 {
@@ -1099,31 +1120,31 @@ void ReleaseInjectionTargets()
     sPrevRigid.clear(); sCurRigid.clear(); sPrevRigidClaimed.clear(); sPrevRigidByMesh.clear();
 }
 
-// Map/Unmap shadow: snapshot the bytes of a known bone-palette CB as OGRE writes them (WRITE_DISCARD
-// just before each skin draw), so InjBindSkinPrev can read the current root bone at draw time.
-void InjNoteMap(void* resource, void* pData)
+// Map/Unmap shadow proxy. A D3D11 WRITE_DISCARD pointer is normally write-combined memory: writing it
+// is fast, but reading it back with memcpy is pathologically slow. For a known bone CB, preserve the
+// real GPU pointer and give OGRE ordinary cached RAM instead. At Unmap we copy cached RAM -> GPU (the
+// intended fast direction), while the same RAM remains available as the CPU shadow.
+void InjNoteMap(void* resource, D3D11_MAP mapType, D3D11_MAPPED_SUBRESOURCE* mapped)
 {
-    if (!sBoneShadowActive || !resource || !pData) return;
-    if (sKnownBoneCB.find((const void*)resource) == sKnownBoneCB.end()) return;
-    sMapPending[(const void*)resource] = pData;
+    if (!sBoneShadowActive || !resource || !mapped || !mapped->pData) return;
+    if (mapType != D3D11_MAP_WRITE_DISCARD) return;
+    auto known = sKnownBoneCB.find((const void*)resource);
+    if (known == sKnownBoneCB.end()) return;
+
+    std::vector<uint8_t>& shadow = sBoneShadow[(const void*)resource];
+    if (shadow.empty()) return;
+    sMapPending[(const void*)resource] = mapped->pData;
+    mapped->pData = shadow.data();
 }
 void InjNoteUnmap(void* resource)
 {
     if (!sBoneShadowActive || !resource) return;
-    auto itp = sMapPending.find((const void*)resource);
-    if (itp == sMapPending.end()) return;
-    uint32_t sz = sKnownBoneCB[(const void*)resource];
-    // The map key is a raw COM pointer with no ref held, so the address can have been recycled by a
-    // SMALLER buffer since the CB was learned — clamp to the resource's current ByteWidth before
-    // copying. GetDesc sits at the same vtable slot for every ID3D11Resource child; size the local
-    // for the largest desc so a recycled texture can't smash the stack.
-    union { D3D11_BUFFER_DESC bd; D3D11_TEXTURE2D_DESC td; } desc = {};
-    ((ID3D11Buffer*)resource)->GetDesc(&desc.bd);
-    if (desc.bd.ByteWidth < sz) sz = desc.bd.ByteWidth;
-    std::vector<uint8_t>& dst = sBoneShadow[(const void*)resource];
-    if (dst.size() != sz) dst.resize(sz);
-    if (sz && itp->second) memcpy(dst.data(), itp->second, sz);
-    sMapPending.erase(itp);
+    auto pending = sMapPending.find((const void*)resource);
+    auto shadow = sBoneShadow.find((const void*)resource);
+    if (pending == sMapPending.end() || shadow == sBoneShadow.end()) return;
+    if (!shadow->second.empty())
+        memcpy(pending->second, shadow->second.data(), shadow->second.size());
+    sMapPending.erase(pending);
 }
 
 // POST_LIGHTING: promote THIS frame's skinned poses (recorded at draw time by InjBindSkinPrev from
@@ -1160,66 +1181,70 @@ void InjFillSkinPrev(ID3D11DeviceContext* ctx)
     sPrevClaimed.assign(sPrevSkinPoses.size(), 0);
 }
 
-// Draw hook (right after GeometryCapture::OnDrawIndexed): if the just-captured draw is skinned, read
-// its CURRENT root bone from the CB shadow, spatially match it to a same-mesh previous pose, and bind
-// that pose to b12 before the draw. Match by mesh identity (ib+idxCount+baseVtx) + nearest root, with a
-// one-to-one claim and a distance gate — the verified A.3b scheme (draw-order flashes at 100s of draws).
-void InjBindSkinPrev(ID3D11DeviceContext* ctx)
+// Draw hook: identify the current VS directly, then read the CURRENT root bone from the CB shadow,
+// spatially match it to a same-mesh previous pose, and bind that pose to b12 before the draw.
+void InjBindSkinPrev(ID3D11DeviceContext* ctx, UINT indexCount, INT baseVertexLocation)
 {
     if (!ctx || !sDevice) return;
-    const auto& caps = GeometryCapture::GetCaptures();
-    if (caps.empty()) return;
-    const CapturedDraw& d = caps.back();
+    const VSConstantBufferInfo* vsInfo = CurrentVSInfo(ctx);
     // Unregistered VS (no reflection metadata): we can't prove this ISN'T an injected skin perm, and
     // b12 is sticky — a stale non-zero pose here means wrong-bone reprojection (the MV flash). Never
     // let such a draw read leftovers; the zero CB forces the shader's camera-reproj fallback.
-    if (!d.vsMetadata) { BindSkinZeroB12(ctx); return; }
+    if (!vsInfo) { BindSkinZeroB12(ctx); return; }
     // Reflected STATIC/UNKNOWN classes (objects/terrain/shadow perms) don't declare b12 at all —
     // binding would be a wasted state change, and the stale value is never read.
-    if (d.vsMetadata->transformType != VSTransformType::SKINNED) return;
+    if (vsInfo->transformType != VSTransformType::SKINNED) return;
     sSkinTotalFrame++;
 
-    uint32_t boneOff = d.vsMetadata->boneArrayOffset;
-    uint32_t cbSlot  = d.vsMetadata->cbSlot;
+    uint32_t boneOff = vsInfo->boneArrayOffset;
+    uint32_t cbSlot  = vsInfo->cbSlot;
 
     // Learn this draw's bone-palette CB so the Map/Unmap shadow starts capturing it next frame.
     ID3D11Buffer* boneCB = nullptr;
     ctx->VSGetConstantBuffers(cbSlot, 1, &boneCB);
     if (!boneCB) { BindSkinZeroB12(ctx); return; }
+
+    // Query only the index buffer needed for cross-frame mesh identity.
+    ID3D11Buffer* indexBuffer = nullptr;
+    DXGI_FORMAT indexFormat = DXGI_FORMAT_UNKNOWN;
+    UINT indexOffset = 0;
+    ctx->IAGetIndexBuffer(&indexBuffer, &indexFormat, &indexOffset);
+    ID3D11Buffer* meshId = indexBuffer;
+    if (indexBuffer) indexBuffer->Release();   // keep only the stable pointer value as the identity
+
     if (sKnownBoneCB.find((const void*)boneCB) == sKnownBoneCB.end())
     {
-        if (sKnownBoneCB.size() > 64) { sKnownBoneCB.clear(); sBoneShadow.clear(); sMapPending.clear(); }  // churn backstop
+        if (sKnownBoneCB.size() > 64) ClearBoneShadows();
         D3D11_BUFFER_DESC bd; boneCB->GetDesc(&bd);
         sKnownBoneCB[(const void*)boneCB] = bd.ByteWidth;
+        boneCB->AddRef(); sHeldBoneCB[(const void*)boneCB] = boneCB;
+        sBoneShadow[(const void*)boneCB].resize(bd.ByteWidth);
         sBoneShadowActive = true;
     }
-    auto its = sBoneShadow.find((const void*)boneCB);
+    auto shadow = sBoneShadow.find((const void*)boneCB);
     boneCB->Release();
-    if (its == sBoneShadow.end()) { sSkinShadowMissFrame++; BindSkinZeroB12(ctx); return; }   // not shadowed yet (warmup) -> reproj
-    const std::vector<uint8_t>& cur = its->second;
+    if (shadow == sBoneShadow.end()) { sSkinShadowMissFrame++; BindSkinZeroB12(ctx); return; }
+    const std::vector<uint8_t>& cur = shadow->second;
     if ((size_t)boneOff + 48 > cur.size()) { BindSkinZeroB12(ctx); return; }
 
     const float* bf = (const float*)(cur.data() + boneOff);
     float cr[3] = { bf[3], bf[7], bf[11] };               // current root (bone0 translation, rebased world)
 
-    // Record THIS draw's pose (bones + VP, straight from the CB shadow — already CPU memory) as a
-    // match target for next frame. This replaces the old GPU staging read-back in InjFillSkinPrev,
-    // whose same-frame Map(READ) serialized the CPU and GPU frames (~halved fps). Shadow-missed draws
-    // (first frame a bone CB is seen) returned above and sit out one frame — camera reproj covers them.
+    // Record this draw's exact bone palette + VP as a match target for next frame.
     {
-        uint32_t clipOff  = d.vsMetadata->clipMatrixOffset;
-        uint32_t boneCnt  = d.vsMetadata->boneCount > 60 ? 60 : d.vsMetadata->boneCount;   // b12 declares [60]
-        uint32_t bonesLen = boneCnt * 48;
-        if (boneCnt && d.indexBuffer &&
+        const uint32_t clipOff  = vsInfo->clipMatrixOffset;
+        const uint32_t boneCnt  = vsInfo->boneCount > 60 ? 60 : vsInfo->boneCount;
+        const uint32_t bonesLen = boneCnt * 48;
+        if (boneCnt && meshId &&
             (size_t)boneOff + bonesLen <= cur.size() && (size_t)clipOff + 64 <= cur.size() &&
             sCurSkinPoses.size() < 4096)
         {
             SkinPose p;
             p.b12.assign(kB12Size, 0);
-            memcpy(p.b12.data(),        cur.data() + boneOff, bonesLen);   // bones @ 0
-            memcpy(p.b12.data() + 2880, cur.data() + clipOff, 64);         // VP    @ 2880
+            memcpy(p.b12.data(),        cur.data() + boneOff, bonesLen);
+            memcpy(p.b12.data() + 2880, cur.data() + clipOff, 64);
             p.root[0] = cr[0]; p.root[1] = cr[1]; p.root[2] = cr[2];
-            p.ib = d.indexBuffer; p.idxCount = d.indexCount; p.baseVtx = d.baseVertexLocation;
+            p.ib = meshId; p.idxCount = indexCount; p.baseVtx = baseVertexLocation;
             sCurSkinPoses.push_back(std::move(p));
         }
     }
@@ -1232,16 +1257,16 @@ void InjBindSkinPrev(ID3D11DeviceContext* ctx)
     // into MISSES, which are safe (zero b12 -> camera reproj) instead of wrong.
     const float kGate2 = 2.0f * 2.0f;                     // rebased world units^2
     int best = -1; float bestD = 1e30f;
-    for (size_t j = 0; j < sPrevSkinPoses.size(); j++)
+    for (size_t j = 0; j < sPrevSkinPoses.size(); ++j)
     {
         if (sPrevClaimed[j]) continue;
         const SkinPose& p = sPrevSkinPoses[j];
-        if (p.ib != d.indexBuffer || p.idxCount != d.indexCount || p.baseVtx != d.baseVertexLocation) continue;
+        if (p.ib != meshId || p.idxCount != indexCount || p.baseVtx != baseVertexLocation) continue;
         float dx = cr[0]-p.root[0], dy = cr[1]-p.root[1], dz = cr[2]-p.root[2];
         float dd = dx*dx + dy*dy + dz*dz;
         if (dd < bestD) { bestD = dd; best = (int)j; }
     }
-    if (best < 0 || bestD > kGate2) { BindSkinZeroB12(ctx); return; }   // no confident prev -> zero b12 -> camera reproj
+    if (best < 0 || bestD > kGate2) { BindSkinZeroB12(ctx); return; }   // no confident prev -> camera reproj
     sPrevClaimed[best] = 1;
     sSkinMatchedFrame++;
 
@@ -1262,16 +1287,14 @@ void InjBindSkinPrev(ID3D11DeviceContext* ctx)
     else BindSkinZeroB12(ctx);
 }
 
-// DrawIndexedInstanced hook (right after GeometryCapture::OnDrawIndexedInstanced): instanced draws
-// skip the pose matcher (per-instance palettes make identity ambiguous), so give any instanced
+// DrawIndexedInstanced hook: instanced draws skip the pose matcher (per-instance palettes make
+// identity ambiguous), so give any instanced
 // SKINNED draw the zero CB — camera-reproj fallback — instead of the previous draw's sticky pose.
 void InjBindZeroB12(ID3D11DeviceContext* ctx)
 {
     if (!ctx || !sDevice) return;
-    const auto& caps = GeometryCapture::GetCaptures();
-    if (caps.empty()) return;
-    const CapturedDraw& d = caps.back();
-    if (!d.vsMetadata || d.vsMetadata->transformType != VSTransformType::SKINNED) return;
+    const VSConstantBufferInfo* vsInfo = CurrentVSInfo(ctx);
+    if (!vsInfo || vsInfo->transformType != VSTransformType::SKINNED) return;
     BindSkinZeroB12(ctx);
 }
 
@@ -1324,9 +1347,11 @@ void InjBindRigidPrev(ID3D11DeviceContext* ctx)
     {
         if (sKnownBoneCB.find((const void*)clipCB) == sKnownBoneCB.end())
         {
-            if (sKnownBoneCB.size() > 96) { sKnownBoneCB.clear(); sBoneShadow.clear(); sMapPending.clear(); }
+            if (sKnownBoneCB.size() > 96) ClearBoneShadows();
             D3D11_BUFFER_DESC bd; clipCB->GetDesc(&bd);
             sKnownBoneCB[(const void*)clipCB] = bd.ByteWidth;
+            clipCB->AddRef(); sHeldBoneCB[(const void*)clipCB] = clipCB;
+            sBoneShadow[(const void*)clipCB].resize(bd.ByteWidth);
             sBoneShadowActive = true;
         }
         auto it = sBoneShadow.find((const void*)clipCB);
@@ -1609,8 +1634,7 @@ void Shutdown()
     if (sInjRigidB12) { sInjRigidB12->Release(); sInjRigidB12 = nullptr; }
     if (sRigidZeroB12){ sRigidZeroB12->Release(); sRigidZeroB12 = nullptr; }
     sPrevRigid.clear(); sCurRigid.clear(); sPrevRigidClaimed.clear(); sPrevRigidByMesh.clear();
-    sBoneShadowActive = false;
-    sKnownBoneCB.clear(); sMapPending.clear(); sBoneShadow.clear();
+    ClearBoneShadows();
     sPrevSkinPoses.clear(); sCurSkinPoses.clear(); sPrevClaimed.clear();
     sInjHavePrev = false; sInjBegun = false; sHaveFwd = false;
     if (sVelVS) { sVelVS->Release(); sVelVS = nullptr; }

--- a/src/MotionVectors.h
+++ b/src/MotionVectors.h
@@ -49,18 +49,17 @@ namespace MotionVectors
     void ReleaseInjectionTargets();
 
     // True skinned-character animation MVs: the patched skin VS skins each vertex with current AND
-    // previous-frame bones (b12). InjBindSkinPrev (per skinned GBuffer draw, after
-    // GeometryCapture::OnDrawIndexed) binds the matched previous pose to b12 before the draw AND
-    // records this draw's pose from the CB shadow; InjFillSkinPrev (POST_LIGHTING) just promotes the
-    // recorded poses to next frame's match targets (pure CPU swap — no GPU read-back, no stall).
+    // previous-frame bones (b12). InjBindSkinPrev identifies a skinned draw directly, binds the matched
+    // previous pose to b12 before the draw, and records this draw's pose from the CB shadow;
+    // InjFillSkinPrev promotes the recorded poses to next frame's match targets.
     void InjFillSkinPrev(ID3D11DeviceContext* ctx);
-    void InjBindSkinPrev(ID3D11DeviceContext* ctx);
+    void InjBindSkinPrev(ID3D11DeviceContext* ctx, UINT indexCount, INT baseVertexLocation);
 
     // DrawIndexedInstanced hook: instanced draws never run the pose matcher (per-instance bone
     // palettes make cross-frame identity ambiguous), but an instanced SKINNED draw's patched VS
     // still reads b12 — left sticky, that's the previous draw's pose (a wrong-character MV flash).
     // Bind the zero CB so it takes the safe camera-reproj fallback instead. No-op unless the
-    // just-captured draw is skinned.
+    // currently-bound vertex shader is skinned.
     void InjBindZeroB12(ID3D11DeviceContext* ctx);
 
     // A.5 rigid moving-object velocity (weapons/tools/props on animated bones, objects.hlsl). Per-draw
@@ -70,10 +69,10 @@ namespace MotionVectors
     void InjBindRigidPrev(ID3D11DeviceContext* ctx);
     void InjFillRigidPrev(ID3D11DeviceContext* ctx);
 
-    // Bone-palette CB shadow, fed from the Map/Unmap hooks. InjBindSkinPrev needs the CURRENT frame's
-    // root bone at draw time (to spatially match prev poses); these snapshot it stall-free. Cheap
-    // no-ops until a skinned draw teaches the shadow which CB is the bone palette.
-    void InjNoteMap(void* resource, void* pData);
+    // Bone-palette CB shadow, fed from the Map/Unmap hooks. For known WRITE_DISCARD buffers the hook
+    // gives the game cached RAM, then copies that RAM to the real mapped GPU pointer at Unmap. This
+    // preserves the current root pose without ever reading slow write-combined upload memory.
+    void InjNoteMap(void* resource, D3D11_MAP mapType, D3D11_MAPPED_SUBRESOURCE* mapped);
     void InjNoteUnmap(void* resource);
     // Blit the injected velocity RT as colour over the bound target (debug viz).
     void InjDebugBlit(ID3D11DeviceContext* ctx);


### PR DESCRIPTION
## Summary

- Avoid reading from mapped `WRITE_DISCARD` bone constant buffers.
- Preserve Dust's exact previous-bone character motion vectors.
- Replace the unused full geometry-replay snapshot with the few bindings the injected skinned-MV path actually needs.
- Preserve the default `CaptureGeometry=1` behavior.

## Root cause

Diagnostic builds isolated the character-dependent performance collapse to the shadow copy performed between `Map` and `Unmap`.

The previous implementation saved the pointer returned by:

```cpp
Map(..., D3D11_MAP_WRITE_DISCARD, ...)
```

At `Unmap`, it copied **from** that mapped pointer into a CPU shadow buffer. On the affected system, reading this upload-oriented memory was extremely slow. Such mapped memory is commonly write-combined: CPU writes are efficient, but CPU reads can be pathological.

Classification, the required D3D state queries, pose matching, constant-buffer upload, and the skinned shader path retained normal performance when tested separately. Enabling the old mapped-memory read alone reproduced the collapse.

## Fix

For known skinned bone buffers, the new path:

1. Saves the real mapped upload pointer.
2. Gives the game an ordinary cached-RAM shadow buffer as `pData`.
3. At `Unmap`, copies the cached RAM **to** the real mapped pointer.
4. Keeps the same cached bytes for previous-pose matching.

The game still uploads exactly the data it wrote, but Dust never reads from the `WRITE_DISCARD` mapping.

The injected path also identifies skinned draws using only the current vertex shader, bone constant buffer, and index buffer instead of constructing the legacy full `CapturedDraw` replay state.

## Test results

Tested in the same character-heavy scene with approximately 15 visible characters and FSR3/4 temporal AA enabled, using a 9060 XT at 2560x1440:

- Previous Map/Unmap shadow-copy path: approximately 16–18 FPS
- Fixed proxy path: approximately 47 FPS
- A comparison with `CaptureGeometry=0` in INI shows near identical performance
- Final surgical build with `CaptureGeometry` absent from the INI, therefore using its default value of `1`: approximately 47 FPS
- Upscaler-off reference: approximately 57 FPS

Rendering and exact character motion vectors remained correct.
